### PR TITLE
Return status with radio_poll.

### DIFF
--- a/include/radio.h
+++ b/include/radio.h
@@ -18,7 +18,12 @@ comms_layer_t* radio_init(uint16_t channel, uint16_t pan_id, uint16_t address);
 void radio_idle();
 void radio_reenable();
 void radio_reenable_channel_panid(uint16_t channel, uint16_t pan_id);
-void radio_poll(void);
+
+/**
+ * Poll the radio.
+ * @return true if it is doing something.
+ */
+bool radio_poll(void);
 
 // queue -----------------------------------------------------------------------
 typedef struct radio_queue_element radio_queue_element_t;

--- a/silabs/radio_rtos.c
+++ b/silabs/radio_rtos.c
@@ -470,7 +470,7 @@ static void signal_send_done(comms_error_t err) {
 	else err1("snt ? e:%d", err);
 }
 
-void radio_poll() {
+void radio_run() {
 	// If an exception has occurred and RAIL is broken -------------------------
 	if(radio_restart == true) {
 		while(osMutexAcquire(radio_mutex, 1000) != osOK);
@@ -732,8 +732,19 @@ void radio_poll() {
 
 static void radio_thread(void *p) {
 	while(true) {
-		radio_poll();
+		radio_run();
 	}
+}
+
+
+bool radio_poll() {
+	bool busy;
+
+	while(osMutexAcquire(radio_mutex, 1000) != osOK);
+	busy = (radio_msg_sending != NULL)||(radio_msg_queue_head != NULL);
+	osMutexRelease(radio_mutex);
+
+	return busy;
 }
 
 


### PR DESCRIPTION
Make it possible to make decisions about toggling radio when there are other components also accessing the radio send/receive independently.