### PR TITLE
Radio extra conf

### DIFF
--- a/include/eui64.h
+++ b/include/eui64.h
@@ -8,6 +8,7 @@
 #define EUI64_H_
 
 #define EUI64_LENGTH 8
+#define IEEE_EUI64_LENGTH 8
 
 // TODO Must add some actual data structures!
 

--- a/include/radio.h
+++ b/include/radio.h
@@ -45,6 +45,20 @@ void radio_deinit (comms_layer_t * iface);
 void radio_set_promiscuous(bool promiscuous);
 
 /**
+ * Set radio channel.
+ * Will take effect after radio is restarted.
+ * @return true if an acceptable channel was requested.
+ */
+bool radio_set_channel (uint16_t channel);
+
+/**
+ * Get radio channel.
+ * Valid only if radio has been restarted after channel was changed.
+ * @return Radio channel.
+ */
+uint16_t radio_get_channel ();
+
+/**
  * Set radio power mode (select PA).
  * Will take effect after radio is restarted.
  * @return true if an acceptable PA was requested.

--- a/include/radio.h
+++ b/include/radio.h
@@ -38,8 +38,37 @@ comms_layer_t * radio_init(uint16_t channel, uint16_t pan_id, uint16_t address);
  */
 void radio_deinit (comms_layer_t * iface);
 
-// Configure promiscuous mode
+/**
+ * Configure promiscuous mode.
+ * Will take effect after radio is restarted.
+ */
 void radio_set_promiscuous(bool promiscuous);
+
+/**
+ * Set radio power mode (select PA).
+ * Will take effect after radio is restarted.
+ * @return true if an acceptable PA was requested.
+ */
+bool radio_set_power_mode (int pa);
+
+/**
+ * Set radio TX power (dBm).
+ * Will take effect after radio is restarted.
+ */
+void radio_set_tx_power (float pwr);
+
+/**
+ * Configure radio for test stream mode.
+ * Will take effect after radio is restarted.
+ * @return true if an acceptable mode was requested.
+ */
+bool radio_stream_mode_enable (int mode);
+
+/**
+ * Disable radio test stream mode.
+ * Will take effect after radio is restarted.
+ */
+void radio_stream_mode_disable ();
 
 /**
  * Force radio to idle. Only supported on "basic" implementations.

--- a/silabs/radio_rtos.c
+++ b/silabs/radio_rtos.c
@@ -547,7 +547,7 @@ static RAIL_Status_t radio_rail_configure (RAIL_Handle_t handle)
             err1("cfg ant");
             return rs;
         }
-        debug4("cfg ant %d");
+        debug4("cfg ant");
     #endif//_SILICON_LABS_32B_SERIES_2
 
     rs = RAIL_IEEE802154_Init(handle, &m_radio_ieee802154_config);
@@ -558,13 +558,15 @@ static RAIL_Status_t radio_rail_configure (RAIL_Handle_t handle)
     }
     debug4("154 init");
 
-    rs = RAIL_IEEE802154_Config2p4GHzRadio(handle);
-    if (RAIL_STATUS_NO_ERROR != rs)
-    {
-        err1("cfg %d", (int)rs);
-        return NULL;
-    }
-    debug4("154 cfgd");
+    #ifndef RAIL_USE_CUSTOM_CONFIG
+        rs = RAIL_IEEE802154_Config2p4GHzRadio(handle);
+        if (RAIL_STATUS_NO_ERROR != rs)
+        {
+            err1("cfg %d", (int)rs);
+            return rs;
+        }
+        debug4("154 cfgd");
+    #endif//RAIL_USE_CUSTOM_CONFIG
 
     // Config2p4GHzRadio triggers invalid action assert when called with some modules and SDK versions
     if (g_rail_invalid_actions > 0)


### PR DESCRIPTION
Added options for run-time configuration of test mode, power and PA. Initially needed for test software.

Does anyone know of a better way for selecting the PA through constants? Old one was very verbose, new one requires funny quotes. Using numbers does not seem like a good idea, at least the letters give context.