### PR TITLE
Warn when Rx msg dropped and packet age is more than 5000us

### DIFF
--- a/silabs/radio_rtos.c
+++ b/silabs/radio_rtos.c
@@ -1295,7 +1295,10 @@ static void stop_radio_now ()
     RAIL_RxPacketHandle_t rxh;
     while (osOK == osMessageQueueGet(m_rx_queue, &rxh, NULL, 0))
     {
-        warn2("rm rxmsg age:%"PRIu32"us", rail_packet_age(rxh));
+        if (rail_packet_age(rxh) > 5000)
+        {
+            warn2("rm rxmsg age:%"PRIu32"us", rail_packet_age(rxh));
+        }
         RAIL_Status_t rst = RAIL_ReleaseRxPacket(m_rail_handle, rxh);
         if (rst != RAIL_STATUS_NO_ERROR)
         {


### PR DESCRIPTION
When packet age is less than 5000us then it is normal to drop.