### PR TITLE
Hard reset flash init

### DIFF
--- a/include/platform.h
+++ b/include/platform.h
@@ -86,4 +86,9 @@ void PLATFORM_ClearGpioPin(uint8_t pin_nr);
  */
 void PLATFORM_ToggleGpioPin(uint8_t pin_nr);
 
+/**
+ * Perform a hard-reset when possible, a soft-reset when not.
+ */
+void PLATFORM_HardReset();
+
 #endif//_PLATFORM_H_

--- a/include/spi_flash.h
+++ b/include/spi_flash.h
@@ -9,6 +9,7 @@
 #define _SPI_FLASH_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 struct spi_flash_partitions_struct
 {
@@ -19,8 +20,10 @@ struct spi_flash_partitions_struct
 
 /**
  * Initialize the SPI flash component.
+ * @return true if flash working,
+ *         false intialization failed - flash did not respond.
  */
-void spi_flash_init(void);
+bool spi_flash_init(void);
 
 /**
  * Suspend the SPI flash to save power, resume is automatic.
@@ -30,8 +33,9 @@ void spi_flash_suspend(void);
 
 /**
  * Explicitly wake the flash, normally done automatically.
+ * @return true if flash working, false if resume failed.
  */
-void spi_flash_resume(void);
+bool spi_flash_resume(void);
 
 void spi_flash_cmd(uint8_t cmd);
 uint8_t spi_flash_status(void);

--- a/widgets/basic_rtos_logger_setup.c
+++ b/widgets/basic_rtos_logger_setup.c
@@ -14,6 +14,8 @@
 #include "em_usart.h"
 #include "logger_fwrite_basic.h"
 
+#include "platform_mutex.h"
+
 #include "loggers_ext.h"
 #if defined(LOGGER_LDMA)
 #include "logger_ldma.h"


### PR DESCRIPTION
Use hard-reset when flash init fails. Add status info so failure is known. Basic_rtos_setup decides what to do on it's own, but in most cases false return value should be enough to immediately call hard reset (bootloader will do it like that). Hard-reset should be implemented for each platform.c file.